### PR TITLE
options refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,5 @@ tools/**
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+VersionAssemblyInfo.cs

--- a/VersionAssemblyInfo.cs
+++ b/VersionAssemblyInfo.cs
@@ -5,6 +5,6 @@
 //------------------------------------------------------------------------------
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
-[assembly: AssemblyInformationalVersion("0.1.0-ci.2+Branch.master.Sha.d4908c274a6dd84ea0b3c7e5040218deaf8bd0ad")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyInformationalVersion("0.1.1+Branch.master.Sha.6f1e7a5df04dcc3d571ff70136b475c168225f52")]

--- a/sample/Robotify.AspNetCore.Sample/Startup.cs
+++ b/sample/Robotify.AspNetCore.Sample/Startup.cs
@@ -24,14 +24,15 @@ namespace Robotify.AspNetCore.Sample
             Configuration = builder.Build();
         }
 
-        public IConfigurationRoot Configuration { get; }
+        public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton(Configuration);
             services.AddOptions();
 
-            services.AddRobotify(Configuration);
+            services.AddRobotify();
             
             // Add framework services.
             services.AddMvc();

--- a/sample/Robotify.AspNetCore.Sample/appsettings.json
+++ b/sample/Robotify.AspNetCore.Sample/appsettings.json
@@ -5,7 +5,7 @@
       "Default": "Warning"
     }
   },
-  "Robotyify": {
+  "Robotify": {
     "Enabled": true,
     "SitemapUrl": "https://www.example.com/sitemap.xml",
     "CrawDelay": 10,

--- a/src/ConfigureRobotifyOptions.cs
+++ b/src/ConfigureRobotifyOptions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Robotify.AspNetCore
+{
+    public class ConfigureRobotifyOptions : IConfigureOptions<RobotifyOptions>
+    {
+        private readonly IConfiguration configuration;
+
+        public ConfigureRobotifyOptions(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+        
+        public void Configure(RobotifyOptions options)
+        {
+            configuration.GetSection("Robotify").Bind(options);
+            var groups = configuration.GetSection("Robotify:Groups").Get<IList<RobotsGroup>>();
+            options.Groups = groups ?? new List<RobotsGroup>();
+        }
+    }
+}

--- a/src/IRobotifyContentWriter.cs
+++ b/src/IRobotifyContentWriter.cs
@@ -1,0 +1,7 @@
+namespace Robotify.AspNetCore
+{
+    public interface IRobotifyContentWriter
+    {
+        string Write();
+    }
+}

--- a/src/RobotifyContentWriter.cs
+++ b/src/RobotifyContentWriter.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Robotify.AspNetCore
+{
+    public class RobotifyContentWriter : IRobotifyContentWriter
+    {
+        private readonly RobotifyOptions options;
+
+        public RobotifyContentWriter(IOptions<RobotifyOptions> options)
+        {
+            this.options = options.Value;
+        }
+        
+        protected string GenerateSyntaxLine<T>(string key, T value)
+        {
+            return $"{key}: {value}";
+        }
+
+        public string Write()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"# Generated with {GetType().GetTypeInfo().Assembly.GetName().Name} (v{GetType().GetTypeInfo().Assembly.GetName().Version})");
+            sb.AppendLine($"# created: {DateTimeOffset.UtcNow:s}\n");
+
+            if (options.CrawlDelay.HasValue && options.CrawlDelay > 0)
+            {
+                sb.AppendLine(GetCrawlDelay(options.CrawlDelay.Value));
+            }
+
+            if (options.SitemapUrl != null && options.SitemapUrl.IsAbsoluteUri)
+            {
+                sb.AppendLine(GetSitemapUrl(options.SitemapUrl));
+            }
+
+            if (options.HasGroups())
+            {
+                sb.AppendLine();
+                foreach (var group in options.Groups)
+                {
+                    sb.AppendLine(GetRobotsGroup(group));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        protected virtual string GetRobotsGroup(RobotsGroup group)
+        {
+            return group.ToString();
+        }
+
+        protected virtual string GetSitemapUrl(Uri sitemapUrl)
+        {
+            return GenerateSyntaxLine("sitemap", sitemapUrl);
+        }
+
+        protected virtual string GetCrawlDelay(int crawlDelay)
+        {
+            return GenerateSyntaxLine("crawl-delay", crawlDelay);
+        }
+    }
+}

--- a/src/RobotifyOptions.cs
+++ b/src/RobotifyOptions.cs
@@ -2,56 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using Microsoft.Extensions.Options;
 
 namespace Robotify.AspNetCore
 {
-    public interface IRobotifyContentWriter
-    {
-        string Write();
-    }
-    
-    public class RobotifyContentWriter : IRobotifyContentWriter
-    {
-        private readonly RobotifyOptions options;
-
-        public RobotifyContentWriter(IOptions<RobotifyOptions> options)
-        {
-            this.options = options.Value;
-        }
-        
-        public string Write()
-        {
-            var sb = new StringBuilder();
-
-            sb.AppendLine($"# Generated with {GetType().GetTypeInfo().Assembly.GetName().Name} (v{GetType().GetTypeInfo().Assembly.GetName().Version})");
-            sb.AppendLine($"# created: {DateTimeOffset.UtcNow:s}\n");
-
-            if (options.CrawlDelay.HasValue && options.CrawlDelay > 0)
-            {
-                sb.AppendLine($"crawl-delay: {options.CrawlDelay}");
-            }
-
-            if (options.SitemapUrl != null && options.SitemapUrl.IsAbsoluteUri)
-            {
-                sb.AppendLine($"sitemap: {options.SitemapUrl}");
-            }
-
-            if (options.HasGroups())
-            {
-                sb.AppendLine();
-                foreach (var group in options.Groups)
-                {
-                    sb.AppendLine(group.ToString());
-                }
-            }
-
-            return sb.ToString();
-        }
-    }
-
     public sealed class RobotifyOptions
     {
         public bool Enabled { get; set; } = true;

--- a/src/RobotifyServiceCollectionExtensions.cs
+++ b/src/RobotifyServiceCollectionExtensions.cs
@@ -1,26 +1,40 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
 
 namespace Robotify.AspNetCore
 {
     public static class RobotifyServiceCollectionExtensions
     {
+        private static IServiceCollection AddRobotifyServices(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.TryAddSingleton<IRobotifyContentWriter, RobotifyContentWriter>();
+            serviceCollection.TryAddSingleton<RobotifyMiddleware>();
+            return serviceCollection;
+        }
+
+        public static IServiceCollection AddRobotify(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddOptions();
+            serviceCollection.TryAddSingleton<IConfigureOptions<RobotifyOptions>, ConfigureRobotifyOptions>();
+            serviceCollection.Configure<RobotifyOptions>(_ => { });
+
+            return serviceCollection.AddRobotifyServices();
+        }
+
+        [Obsolete("Use AddRobotify() instead, this will be removed in a future version")]        
         public static IServiceCollection AddRobotify(this IServiceCollection serviceCollection, IConfiguration configuration)
         {
             serviceCollection.AddOptions();
             serviceCollection.Configure<RobotifyOptions>(robotifyOptions =>
             {
-                configuration.GetSection("Robotify").Bind(robotifyOptions);
-                var groups = configuration.GetSection("Robotify:Groups").Get<IList<RobotsGroup>>();
-                robotifyOptions.Groups = groups ?? new List<RobotsGroup>();
+                var configure = new ConfigureRobotifyOptions(configuration);
+                configure.Configure(robotifyOptions);
             });
 
-            serviceCollection.TryAddSingleton<IRobotifyContentWriter, RobotifyContentWriter>();
-            serviceCollection.TryAddSingleton<RobotifyMiddleware>();
-            
-            return serviceCollection;
+            return serviceCollection.AddRobotifyServices();
         }
     }
 }

--- a/src/RobotsGroup.cs
+++ b/src/RobotsGroup.cs
@@ -10,8 +10,8 @@ namespace Robotify.AspNetCore
     {
 
         public string UserAgent { get; set; }
-        public IList<string> Disallow { get; set; }
-        public IList<string> Allow { get; set; }
+        public IList<string> Disallow { get; set; } = Enumerable.Empty<string>().ToList();
+        public IList<string> Allow { get; set; } = Enumerable.Empty<string>().ToList();
         
         internal void MergePaths(StringValues disallowPaths, StringValues allowPaths)
         {


### PR DESCRIPTION
options refactoring  to more closely align with .net core 2 standards.

`.AddRobotifyOptions(configuration)` is deprecated in favour of using `.AddRobotifyOptions()`, configuration is parsed from the DI container.  This means that `IConfiguration` will need to be added to the DI container via:

```c#
IConfiguration Configuration { get; }
...
services.AddSingleton(Configuration);
```